### PR TITLE
Add click sound to the `btnLaunchGame` button

### DIFF
--- a/Resources/GameLobbyBase.ini
+++ b/Resources/GameLobbyBase.ini
@@ -34,6 +34,7 @@ $CC17=btnSaveLoadGameOptions:XNAClientButton
 
 [btnLaunchGame]
 Text=Launch Game
+ClickSoundEffect=button.wav
 ;TextShadowDistance=2
 $Width=133
 $X=EMPTY_SPACE_SIDES


### PR DESCRIPTION
My teammates constantly have a problem that they can not understand if `I'm Ready` button has clicked or not due to the IRC ping. I suggest that adding a click sound will help them and other people.