### PR TITLE
Set `singlecpu` to `false` in cnc-ddraw config

### DIFF
--- a/Resources/cnc-ddraw.ini
+++ b/Resources/cnc-ddraw.ini
@@ -120,7 +120,8 @@ nonexclusive=false
 
 ; Force CPU0 affinity, avoids crashes/freezing, *might* have a performance impact
 ; Note: Disable this if the game is not running smooth or there are sound issues
-singlecpu=true
+; Note (2025-05-06): bugged in 'true', better to use 'false'
+singlecpu=false
 
 ; Available display resolutions, possible values: 0 = Small list, 1 = Very small list, 2 = Full list
 ; Note: Set this to 2 if your chosen resolution is not working or does not show up in the list


### PR DESCRIPTION
Quote from @Metadorius:

> @YR and probably @TS too, not sure of the others
apparently latest Win11 24H2 degrades performance of single processor affinity (assuming that's what singlecpu=true does in cnc-ddraw) and even produces freezes
DDrawCompat 0.6.0 fixes this, and for cnc-ddraw configs you have to put singlecpu=false in config